### PR TITLE
Run scripts when readyState is interactive

### DIFF
--- a/assets/layout.ejs
+++ b/assets/layout.ejs
@@ -385,15 +385,35 @@
     (function () {
       var onLoadDocumentElement
       var onLoadDocumentCopy
+      var called
 
-      onDOMReady(function () {
+      onReadyStateChange(documentIsReady)
+
+      function documentIsReady() {
         onLoadDocumentCopy = document.body.children[0].outerHTML
         onLoadDocumentElement = hashString(onLoadDocumentCopy);
 
         onDOMChange(function () {
           document.body.innerHTML = onLoadDocumentCopy;
         })
-      })
+      }
+
+      function onReadyStateChange(callback) {
+        if ( !('onreadystatechange' in document) ) {
+          onDOMReady(callback)
+
+          return
+        }
+
+        document.onreadystatechange = function () {
+          if (called) return
+
+          if (document.readyState === 'interactive' || document.readyState === 'complete') {
+              called = true
+              callback()
+          }
+        }
+      }
 
       function onDOMReady(callback) {
         if (document.readyState === 'complete') return callback();


### PR DESCRIPTION
I created an extension for Chrome and Firefox with the following content script

``` js
document.body.innerHTML = document.body.innerHTML.replace(/\d{5}\.\d{5} \d{5}\.\d{6} \d{5}\.\d{6} \d \d{14}/, '00000.00000 00000.000000 00000.000000 0 00000000000777')
```

It hacked boleto code in Chrome, but not in Firefox, to avoid it on Chrome `onreadystatechange` was used checking for `interactive`.  The `complete` is fired too late. There's also a fallback in case onreadystatechange isn't available in document.

I tried it on IE8 and IE8 with IE7 mode and it works fine, could not make a actual test in IE6 and IE7 VMs yet.
