### PR TITLE
Fix dates issues

### DIFF
--- a/lib/boleto.js
+++ b/lib/boleto.js
@@ -1,7 +1,8 @@
-var ejs = require('ejs')
-var formatters = require('./formatters')
-var barcode = require('./barcode')
-var path = require('path')
+const ejs = require('ejs')
+const formatters = require('./formatters')
+const barcode = require('./barcode')
+const path = require('path')
+const moment = require('moment')
 
 var banks = null
 
@@ -31,11 +32,15 @@ var Boleto = function (options) {
   }
 
   if (!options['data_emissao']) {
-    options['data_emissao'] = new Date()
+    options['data_emissao'] = moment().utc()
+  } else {
+    options['data_emissao'] = moment(moment(options['data_emissao']).utc().format('YYYY-MM-DD'))
   }
 
   if (!options['data_vencimento']) {
-    options['data_vencimento'] = new Date(new Date().getTime() + (5 * 24 * 3600 * 1000))
+    options['data_vencimento'] = moment().utc().add('5', 'days')
+  } else {
+    options['data_vencimento'] = moment(moment(options['data_vencimento']).utc().format('YYYY-MM-DD'))
   }
 
   for (var key in options) {

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -31,8 +31,7 @@ exports.formatAmount = function (amount) {
 }
 
 exports.formatDate = function (date) {
-  return exports.addTrailingZeros(date.getDate(), 2) + '/' +
-    exports.addTrailingZeros(date.getMonth() + 1, 2) + '/' + date.getFullYear()
+  return moment(date).format('DD/MM/YYYY')
 }
 
 exports.mod11 = function (num, base, r) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-boleto",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Boleto generator in Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/e2e/boleto-render.spec.js
+++ b/test/e2e/boleto-render.spec.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const chai = require('chai')
 chai.use(require('chai-string'))
 const expect = chai.expect
@@ -7,8 +8,8 @@ const boletoOutput = require('./boleto-output')
 
 const createBoleto = (bank) => new Boleto({
   'banco': bank,
-  'data_emissao': new Date(2017, 0, 1),
-  'data_vencimento': new Date(2017, 0, 5),
+  'data_emissao': moment('2017-01-01').format(),
+  'data_vencimento': moment('2017-01-05').format(),
   'valor': 1500,
   'nosso_numero': '6',
   'numero_documento': '1',

--- a/test/mocks/banks.js
+++ b/test/mocks/banks.js
@@ -1,0 +1,13 @@
+const R = require('ramda')
+
+module.exports = {
+  test: {
+    options: {
+      logoURL: 'https://pagar.me/img.png',
+      codigo: '123'
+    },
+    barcodeData: R.always('123'),
+    linhaDigitavel: R.always('123')
+  }
+}
+

--- a/test/mocks/boleto-2018-10-31.js
+++ b/test/mocks/boleto-2018-10-31.js
@@ -1,0 +1,25 @@
+const moment = require('moment')
+const testBanks = require('./banks')
+const Boleto = require('../../lib/boleto')(testBanks)
+
+const dataEmissao = moment(moment('2018-10-25 20:48:01.981+00').utc().format('YYYY-MM-DD')).valueOf()
+const dataVencimento = moment(moment('2018-10-31 02:00:00+00').utc().format('YYYY-MM-DD')).valueOf()
+
+const boletoOptions = {
+  banco: 'test',
+  cedente: 'SOGNI COMERCIO E SERVICO DIGITAL | Pagar.me Pagamentos S/A',
+  cedente_cnpj: '18727053000174',
+  agencia: '1229',
+  codigo_cedente: '469',
+  carteira: '26',
+  data_emissao: new Date(dataEmissao),
+  data_vencimento: new Date(dataVencimento),
+  valor: 1000,
+  nosso_numero: 20615808,
+  numero_documento: 20615808,
+  pagador: 'Abilio Cipriano',
+  local_de_pagamento: 'PAGÁVEL EM QUALQUER BANCO ATÉ O VENCIMENTO.',
+  instrucoes: 'teste'
+}
+
+module.exports = new Boleto(boletoOptions)

--- a/test/mocks/boleto-2018-11-09.js
+++ b/test/mocks/boleto-2018-11-09.js
@@ -1,0 +1,25 @@
+const moment = require('moment')
+const testBanks = require('./banks')
+const Boleto = require('../../lib/boleto')(testBanks)
+
+const dataEmissao = moment(moment('2018-10-25 20:48:01.981+00').utc().format('YYYY-MM-DD')).valueOf()
+const dataVencimento = moment(moment('2018-11-09 02:00:00+00').utc().format('YYYY-MM-DD')).valueOf()
+
+const boletoOptions = {
+  banco: 'test',
+  cedente: 'SOGNI COMERCIO E SERVICO DIGITAL | Pagar.me Pagamentos S/A',
+  cedente_cnpj: '18727053000174',
+  agencia: '1229',
+  codigo_cedente: '469',
+  carteira: '26',
+  data_emissao: new Date(dataEmissao),
+  data_vencimento: new Date(dataVencimento),
+  valor: 1000,
+  nosso_numero: 20615808,
+  numero_documento: 20615808,
+  pagador: 'Abilio Cipriano',
+  local_de_pagamento: 'PAGÁVEL EM QUALQUER BANCO ATÉ O VENCIMENTO.',
+  instrucoes: 'teste'
+}
+
+module.exports = new Boleto(boletoOptions)

--- a/test/unit/boleto-object.spec.js
+++ b/test/unit/boleto-object.spec.js
@@ -1,20 +1,12 @@
 const R = require('ramda')
+const moment = require('moment')
 
 const chai = require('chai')
 chai.use(require('chai-subset'))
 chai.use(require('chai-datetime'))
 const expect = chai.expect
 
-const testBanks = {
-  test: {
-    options: {
-      logoURL: 'https://pagar.me/img.png',
-      codigo: '123'
-    },
-    barcodeData: R.always('123'),
-    linhaDigitavel: R.always('123')
-  }
-}
+const testBanks = require('../mocks/banks')
 const Boleto = require('../../lib/boleto')(testBanks)
 
 describe('Boleto Object', () => {
@@ -52,11 +44,11 @@ describe('Boleto Object', () => {
     })
 
     it('has current date as data_emissao', () => {
-      expect(boleto.data_emissao).to.equalDate(new Date())
+      expect(moment(boleto.data_emissao).format()).to.be.equal(moment().utc().format())
     })
 
     it('has five days past data_emissao as data_vencimento', () => {
-      expect(boleto.data_vencimento).to.equalDate(new Date(new Date().getTime() + (5 * 24 * 3600 * 1000)))
+      expect(moment(boleto.data_vencimento).format()).to.be.equal(moment().utc().add(5, 'days').format())
     })
   })
 
@@ -123,8 +115,8 @@ describe('Boleto Object', () => {
     })
 
     it('contains dates in options', () => {
-      expect(boleto.data_emissao).to.equalTime(boletoOptions.data_emissao)
-      expect(boleto.data_vencimento).to.equalTime(boleto.data_vencimento)
+      expect(moment(boleto.data_emissao).format()).to.be.equal(moment(boletoOptions.data_emissao).format())
+      expect(moment(boleto.data_vencimento).format()).to.be.equal(moment(boleto.data_vencimento).format())
     })
 
     it('contains formatted nosso_numero_dv', () => {

--- a/test/unit/boleto-render.spec.js
+++ b/test/unit/boleto-render.spec.js
@@ -1,0 +1,34 @@
+const boletoMock20181109 = require('../mocks/boleto-2018-11-09')
+const boletoMock20181031 = require('../mocks/boleto-2018-10-31')
+const expect = require('chai').expect
+
+describe('Boleto render', () => {
+  describe('boleto from 2018-11-09', () => {
+    let boletoHTML20181109, boletoHTML20181031
+    before(() => {
+      return new Promise((resolve, reject) => {
+        boletoMock20181109.renderHTML(function (html) {
+          boletoHTML20181109 = html
+          resolve(html)
+        })
+      })
+    })
+
+    before(() => {
+      return new Promise((resolve, reject) => {
+        boletoMock20181031.renderHTML(function (html) {
+          boletoHTML20181031 = html
+          resolve(html)
+        })
+      })
+    })
+
+    it('should have the expiration date as 09/11/2018', () => {
+      expect(boletoHTML20181109.includes('09/11/2018')).to.be.equal(true)
+    })
+
+    it('should have the expiration date as 31/10/2018', () => {
+      expect(boletoHTML20181031.includes('31/10/2018')).to.be.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
This PR aims to fix a couple problems we were facing at the expiration_date at the html render function.
The fix was mostly done by changing the default Date api and use instead `moment`.
One of the main points is that now the expiration_date doesn't take in account the hours, so it won't make any difference if the expiration_date is for example at `2018-10-31 02:00:00`.

