### PR TITLE
bradesco: parse de mais informações do edi file

### DIFF
--- a/banks/bradesco/index.js
+++ b/banks/bradesco/index.js
@@ -125,7 +125,6 @@ exports.parseEDIFile = function (fileContent) {
         boleto['data_ocorrencia'] = helper.dateFromEdiDate(line.substring(110, 116))
         boleto['data_credito'] = helper.dateFromEdiDate(line.substring(295, 301))
         boleto['vencimento'] = helper.dateFromEdiDate(line.substring(110, 116))
-        boleto['valor_pago'] = formatters.removeTrailingZeros(line.substring(253, 266))
         boleto['valor'] = formatters.removeTrailingZeros(line.substring(152, 165))
         boleto['banco_recebedor'] = formatters.removeTrailingZeros(line.substring(165, 168))
         boleto['agencia_recebedora'] = formatters.removeTrailingZeros(line.substring(168, 173))
@@ -134,6 +133,14 @@ exports.parseEDIFile = function (fileContent) {
         boleto['edi_line_checksum'] = ediHelper.calculateLineChecksum(line)
         boleto['edi_line_fingerprint'] = boleto['edi_line_number'] + ':' + boleto['edi_line_checksum']
         boleto['nosso_numero'] = formatters.removeTrailingZeros(line.substring(70, 81))
+
+        boleto['juros_operacao_em_atraso'] = formatters.removeTrailingZeros(line.substring(201, 214))
+        boleto['iof_devido'] = formatters.removeTrailingZeros(line.substring(214, 227))
+        boleto['abatimento_concedido'] = formatters.removeTrailingZeros(line.substring(227, 240))
+        boleto['desconto_concedido'] = formatters.removeTrailingZeros(line.substring(240, 253))
+        boleto['valor_pago'] = formatters.removeTrailingZeros(line.substring(253, 266))
+        boleto['juros_mora'] = formatters.removeTrailingZeros(line.substring(266, 279))
+        boleto['outros_creditos'] = formatters.removeTrailingZeros(line.substring(279, 292))
 
         parsedFile.boletos.push(boleto)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-boleto",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Boleto generator in Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/integration/bradesco/edi.spec.js
+++ b/test/integration/bradesco/edi.spec.js
@@ -7,20 +7,23 @@ const ediParser = require('../../../index').EdiParser
 
 const ediFileContent = `
 02RETORNO01COBRANCA       00000000000004628596PAGAR.ME PAGAMENTOS S.A.      237BRADESCO       2005160160000000001                                                                                                                                                                                                                                                                          220514         000001
-1021872705300017400000250122900004693                         000000000000000000600000000000000000000000000506200516          00000000000000000000000000000000000150034103830  000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000   210516             00000000000000                                                                  000002
+1021872705300017400000250122900004693                         000000000000000000600000000000000000000000000506200516          00000000000000000000000000000000000150034103830  000000000000000000000000000000000000100000000000020000000000003000000000000400000000000010000000000005000000000000600   210516             00000000000000                                                                  000002
+1021872705300017400000260122900004693                         00000000000278613362000000000000000000000000060610041927861336  00000000000278613362090419000000000060934100262  000000000000000000000000000000000000000000000000000000000000000000000000000000000000000071400000000001050000000000000   110419             00000000000000                                                                  152328
 9201237          000000010000000000150000000001          00000000000000000000000000500000010000000005000000000000000000000000000000000000000000000000000000000000000000000000000000000000000                                                                                                                                                                              00000000000000000000000         000003`
 
 describe('Bradesco EDI Parser', () => {
   describe('when parsing a valid EDI file', () => {
     let result
     let boleto
+    let boleto2
     before(() => {
       result = ediParser.parse('bradesco', ediFileContent)
       boleto = result.boletos[0]
+      boleto2 = result.boletos[1]
     })
 
     it('should have found 1 boleto', () => {
-      expect(result.boletos).to.have.lengthOf(1)
+      expect(result.boletos).to.have.lengthOf(2)
     })
 
     it('should parse boleto correctly', () => {
@@ -35,13 +38,47 @@ describe('Bradesco EDI Parser', () => {
         ],
         valor_pago: '100',
         valor: '1500',
+        juros_operacao_em_atraso: '100',
+        iof_devido: '200',
+        abatimento_concedido: '300',
+        desconto_concedido: '400',
+        juros_mora: '500',
+        outros_creditos: '600',
         banco_recebedor: '341',
         agencia_recebedora: '3830',
         paid: true,
         edi_line_number: 2,
-        edi_line_checksum: '3bc78a0fa0897ab07f14f17a6b723f1ca6140f93',
-        edi_line_fingerprint: '2:3bc78a0fa0897ab07f14f17a6b723f1ca6140f93',
+        edi_line_checksum: '20c5b6ebeb167ffb24ebe64316a3433a193de0bf',
+        edi_line_fingerprint: '2:20c5b6ebeb167ffb24ebe64316a3433a193de0bf',
         nosso_numero: '6'
+      })
+    })
+
+    it('should parse boleto2 correctly', () => {
+      expect(boleto2).to.containSubset({
+        codigo_ocorrencia: '06',
+        motivos_ocorrencia: [
+          '00',
+          '00',
+          '00',
+          '00',
+          '00'
+        ],
+        valor_pago: '714',
+        valor: '609',
+        juros_operacao_em_atraso: '',
+        iof_devido: '',
+        abatimento_concedido: '',
+        desconto_concedido: '',
+        juros_mora: '105',
+        outros_creditos: '',
+        banco_recebedor: '341',
+        agencia_recebedora: '262',
+        paid: true,
+        edi_line_number: 3,
+        edi_line_checksum: '686bf39b5d6533b49466e78391d1eeb593cb0db4',
+        edi_line_fingerprint: '3:686bf39b5d6533b49466e78391d1eeb593cb0db4',
+        nosso_numero: '27861336'
       })
     })
 
@@ -61,7 +98,7 @@ describe('Bradesco EDI Parser', () => {
       expect(result).to.containSubset({
         razao_social: 'PAGAR.ME PAGAMENTOS S.A.      ',
         cnpj: '18727053000174',
-        carteira: '25',
+        carteira: '26',
         agencia_cedente: '1229',
         conta_cedente: '4693'
       })

--- a/test/integration/bradesco/edi.spec.js
+++ b/test/integration/bradesco/edi.spec.js
@@ -22,7 +22,7 @@ describe('Bradesco EDI Parser', () => {
       boleto2 = result.boletos[1]
     })
 
-    it('should have found 1 boleto', () => {
+    it('should have found 2 boletos', () => {
       expect(result.boletos).to.have.lengthOf(2)
     })
 


### PR DESCRIPTION
Adicionamos mais informações no objeto de boleto após o parse do edi file:
- Juros Operação em Atraso
- IOF Devido
- Abatimento Concedido sobre o Título
- Desconto Concedido
- Valor Pago
- Juros de Mora
- Outros Créditos