### PR TITLE
boleto caixa: parses EDI file

### DIFF
--- a/banks/bradesco/helper.js
+++ b/banks/bradesco/helper.js
@@ -1,3 +1,0 @@
-exports.dateFromEdiDate = function (ediDate) {
-  return new Date(parseInt('20' + ediDate.substring(4, 8)), parseInt(ediDate.substring(2, 4)) - 1, parseInt(ediDate.substring(0, 2)))
-}

--- a/banks/bradesco/index.js
+++ b/banks/bradesco/index.js
@@ -1,7 +1,6 @@
 const moment = require('moment')
 var formatters = require('../../lib/formatters')
 var ediHelper = require('../../lib/edi-helper')
-var helper = require('./helper')
 
 exports.options = {
   logoURL: 'https://assets.pagar.me/boleto/images/bradesco.jpg',
@@ -97,7 +96,7 @@ exports.parseEDIFile = function (fileContent) {
 
       if (registro == '0') {
         parsedFile['razao_social'] = line.substring(46, 76)
-        parsedFile['data_arquivo'] = helper.dateFromEdiDate(line.substring(94, 100))
+        parsedFile['data_arquivo'] = ediHelper.dateFromEdiDate(line.substring(94, 100))
       } else if (registro == '1') {
         var boleto = {}
 
@@ -122,9 +121,9 @@ exports.parseEDIFile = function (fileContent) {
         }
 
         boleto['motivos_ocorrencia'] = motivosOcorrencia
-        boleto['data_ocorrencia'] = helper.dateFromEdiDate(line.substring(110, 116))
-        boleto['data_credito'] = helper.dateFromEdiDate(line.substring(295, 301))
-        boleto['vencimento'] = helper.dateFromEdiDate(line.substring(110, 116))
+        boleto['data_ocorrencia'] = ediHelper.dateFromEdiDate(line.substring(110, 116))
+        boleto['data_credito'] = ediHelper.dateFromEdiDate(line.substring(295, 301))
+        boleto['vencimento'] = ediHelper.dateFromEdiDate(line.substring(110, 116))
         boleto['valor'] = formatters.removeTrailingZeros(line.substring(152, 165))
         boleto['banco_recebedor'] = formatters.removeTrailingZeros(line.substring(165, 168))
         boleto['agencia_recebedora'] = formatters.removeTrailingZeros(line.substring(168, 173))

--- a/banks/caixa/index.js
+++ b/banks/caixa/index.js
@@ -1,0 +1,64 @@
+const formatters = require('../../lib/formatters')
+const ediHelper = require('../../lib/edi-helper')
+
+exports.parseEDIFile = function (fileContent) {
+  try {
+    const lines = fileContent.split('\n')
+    const parsedFile = {
+      boletos: []
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const registro = line.substring(0, 1)
+
+      if (registro === '0') {
+        parsedFile['razao_social'] = line.substring(46, 81)
+        parsedFile['data_arquivo'] = ediHelper.dateFromEdiDate(line.substring(99, 105))
+      } else if (registro === '1') {
+        const boleto = {}
+
+        parsedFile['cnpj'] = formatters.removeTrailingZeros(line.substring(3, 17))
+        parsedFile['carteira'] = formatters.removeTrailingZeros(line.substring(106, 108))
+        parsedFile['agencia_cedente'] = formatters.removeTrailingZeros(line.substring(17, 21))
+        parsedFile['conta_cedente'] = formatters.removeTrailingZeros(line.substring(21, 27))
+
+        boleto['codigo_ocorrencia'] = line.substring(108, 110)
+
+        const motivosOcorrencia = line.substring(79, 82).trim()
+
+        let isPaid = (parseInt(boleto['valor_pago']) >= parseInt(boleto['valor']) || boleto['codigo_ocorrencia'] === '21')
+
+        if (motivosOcorrencia !== '') {
+          isPaid = false
+        }
+
+        boleto['motivos_ocorrencia'] = motivosOcorrencia
+        boleto['data_ocorrencia'] = ediHelper.dateFromEdiDate(line.substring(110, 116))
+        boleto['data_credito'] = ediHelper.dateFromEdiDate(line.substring(293, 299))
+        boleto['vencimento'] = ediHelper.dateFromEdiDate(line.substring(146, 152))
+        boleto['valor'] = formatters.removeTrailingZeros(line.substring(152, 165))
+        boleto['banco_recebedor'] = formatters.removeTrailingZeros(line.substring(165, 168))
+        boleto['agencia_recebedora'] = formatters.removeTrailingZeros(line.substring(168, 173))
+        boleto['paid'] = isPaid
+        boleto['edi_line_number'] = i
+        boleto['edi_line_checksum'] = ediHelper.calculateLineChecksum(line)
+        boleto['edi_line_fingerprint'] = boleto['edi_line_number'] + ':' + boleto['edi_line_checksum']
+        boleto['nosso_numero'] = formatters.removeTrailingZeros(line.substring(58, 73))
+        boleto['iof_devido'] = formatters.removeTrailingZeros(line.substring(214, 227))
+        boleto['abatimento_concedido'] = formatters.removeTrailingZeros(line.substring(227, 240))
+        boleto['desconto_concedido'] = formatters.removeTrailingZeros(line.substring(240, 253))
+        boleto['valor_pago'] = formatters.removeTrailingZeros(line.substring(253, 266))
+        boleto['juros_mora'] = formatters.removeTrailingZeros(line.substring(266, 279))
+        boleto['outros_creditos'] = formatters.removeTrailingZeros(line.substring(279, 292))
+
+        parsedFile.boletos.push(boleto)
+      }
+    }
+
+    return parsedFile
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}

--- a/lib/edi-helper.js
+++ b/lib/edi-helper.js
@@ -4,3 +4,10 @@ exports.calculateLineChecksum = function (line) {
   return crypto.createHash('sha1').update(line).digest('hex')
 }
 
+exports.dateFromEdiDate = function (ediDate) {
+  const year = ediDate.substring(4, 8)
+  const month = ediDate.substring(2, 4)
+  const day = ediDate.substring(0, 2)
+
+  return new Date(parseInt('20' + year), parseInt(month) - 1, parseInt(day))
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-boleto",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Boleto generator in Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/integration/caixa/edi.spec.js
+++ b/test/integration/caixa/edi.spec.js
@@ -1,0 +1,95 @@
+const chai = require('chai')
+chai.use(require('chai-subset'))
+chai.use(require('chai-datetime'))
+const expect = chai.expect
+
+const ediParser = require('../../../index').EdiParser
+
+const ediFileContent = `
+02RETORNO01COBRANCA       4497740603          xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  104C ECON FEDERAL 251120                                                                                                                                                                                                                                                                                                 00618000001
+10233649575000199449774060320  011904689                14000000000011834                                 0121251120011904689                     261120000000004611610408575090000000000300004102271120              0000000000000000000000000000000000000000000000046116000000000000000000000000001271120                                                                                               000002
+10233649575000199449774060320  013741801                14000000000011835                                 0121251120013741801                     281120000000001798010400174090000000000300006102271120              0000000000000000000000000000000000000000000000017980000000000000000000000000001271120                                                                                               000003`
+
+describe('Caixa EDI Parser', () => {
+  describe('when parsing a valid EDI file', () => {
+    let result
+    let boleto
+    let boleto2
+    before(() => {
+      result = ediParser.parse('caixa', ediFileContent)
+      boleto = result.boletos[0]
+      boleto2 = result.boletos[1]
+    })
+
+    it('should have found 2 boletos', () => {
+      expect(result.boletos).to.have.lengthOf(2)
+    })
+
+    it('should parse boleto correctly', () => {
+      expect(boleto).to.containSubset({
+        codigo_ocorrencia: '21',
+        motivos_ocorrencia: '',
+        valor_pago: '46116',
+        valor: '46116',
+        iof_devido: '',
+        abatimento_concedido: '',
+        desconto_concedido: '',
+        juros_mora: '',
+        outros_creditos: '',
+        banco_recebedor: '104',
+        agencia_recebedora: '8575',
+        paid: true,
+        edi_line_number: 2,
+        edi_line_checksum: '3310496178977da1288d047339a88a08735b1f60',
+        edi_line_fingerprint: '2:3310496178977da1288d047339a88a08735b1f60',
+        nosso_numero: '11834'
+      })
+    })
+
+    it('should parse boleto2 correctly', () => {
+      expect(boleto2).to.containSubset({
+        codigo_ocorrencia: '21',
+        motivos_ocorrencia: '',
+        valor_pago: '17980',
+        valor: '17980',
+        iof_devido: '',
+        abatimento_concedido: '',
+        desconto_concedido: '',
+        juros_mora: '',
+        outros_creditos: '',
+        banco_recebedor: '104',
+        agencia_recebedora: '174',
+        paid: true,
+        edi_line_number: 3,
+        edi_line_checksum: '8b535f53e0f872f9c68aaf2aa7e41fae6d4c7d0e',
+        edi_line_fingerprint: '3:8b535f53e0f872f9c68aaf2aa7e41fae6d4c7d0e',
+        nosso_numero: '11835'
+      })
+    })
+
+    it('should parse boleto data_ocorrencia correctly', () => {
+      expect(boleto.data_ocorrencia).to.equalDate(new Date(2020, 10, 25))
+    })
+
+    it('should parse boleto data_credito correctly', () => {
+      expect(boleto.data_credito).to.equalDate(new Date(2020, 10, 27))
+    })
+
+    it('should parse boleto vencimento correctly', () => {
+      expect(boleto.vencimento).to.equalDate(new Date(2020, 10, 26))
+    })
+
+    it('should parse EDI properties correctly', () => {
+      expect(result).to.containSubset({
+        razao_social: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  ',
+        cnpj: '33649575000199',
+        carteira: '1',
+        conta_cedente: '740603'
+      })
+
+      it('should parse EDI dates correctly', () => {
+        expect(result.data_arquivo).to.equalDate(new Date(2020, 10, 25))
+      })
+    })
+  })
+})


### PR DESCRIPTION
Este PR adiciona a lógica de analisar os EDI files da Caixa para a conciliação de boletos. A base é a mesma utilizada para o Bradesco, porém algumas posições mudaram de acordo com a [documentação da Caixa](https://stonepayments.atlassian.net/wiki/spaces/ONE/pages/506167534/Concilia+o+boleto+Caixa+Encon+mica+-+CNAB+400). 

Para o teste, utilizei um EDI file que a Mundipagg enviou de exemplo. 

