### PR TITLE
[BPROC-1868] Correção quebra linha no pdf de boletos com juros e multa

### DIFF
--- a/assets/layout.ejs
+++ b/assets/layout.ejs
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title>Visualização de boleto</title>
-  <meta name="robots" content="noindex"> 
+  <meta name="robots" content="noindex">
   <meta name="format-detection" content="telephone=no"/>
   <style media="screen, print" type="text/css">
   body
@@ -18,33 +18,33 @@
 
   img{border:0}
 
-  .cp 
+  .cp
   {
-	  font: bold 10px arial; 
+	  font: bold 10px arial;
 	  color: black
   }
-  .ti 
+  .ti
   {
 	  font: 9px arial, helvetica, sans-serif
   }
-  .ld 
+  .ld
   {
-	  font: bold 15px arial; 
+	  font: bold 15px arial;
 	  color: #000000
   }
-  .ct 
+  .ct
   {
-	  font: 9px "arial narrow"; 
+	  font: 9px "arial narrow";
 	  color: #000033
   }
-  .cn 
+  .cn
   {
-	  font: 9px arial; 
+	  font: 9px arial;
 	  color: black
   }
-  .bc 
+  .bc
   {
-	  font: bold 22px arial; 
+	  font: bold 22px arial;
 	  color: #000000
   }
 
@@ -372,14 +372,6 @@
         <tr class="h13"><td /></tr>
         <tr><td class="Ar">Corte na linha pontilhada</td></tr>
         <tr><td class="cut" /></tr>
-    </table>
-    <table class="ctN w666">
-        <tr class="h13"><td /></tr>
-        <tr class="h13"><td /></tr>
-        <tr class="h13"><td /></tr>
-        <tr class="h13"><td /></tr>
-        <tr class="h13"><td /></tr>
-        <tr class="h13"><td /></tr>
     </table>
 </div>
   <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-boleto",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Boleto generator in Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/e2e/boleto-output.js
+++ b/test/e2e/boleto-output.js
@@ -359,14 +359,6 @@ module.exports = (bankLogo, bankNumber, linhaDigitavel, barcode, bmpBarcode) => 
             <tr><td class="Ar">Corte na linha pontilhada</td></tr>
             <tr><td class="cut" /></tr>
         </table>
-        <table class="ctN w666">
-            <tr class="h13"><td /></tr>
-            <tr class="h13"><td /></tr>
-            <tr class="h13"><td /></tr>
-            <tr class="h13"><td /></tr>
-            <tr class="h13"><td /></tr>
-            <tr class="h13"><td /></tr>
-        </table>
     </div>
       <script>
         (function () {


### PR DESCRIPTION
Tarefa [BPROC-1868](https://mundipagg.atlassian.net/browse/BPROC-1868)

Descrição

Remove um bloco `<table> `no fim da página HTML do layout do boleto. Essa remoção foi motivada pela criação de uma nova página quando há informações completas de juros e multa no campo de instruções no ato da impressão.



[BPROC-1868]: https://mundipagg.atlassian.net/browse/BPROC-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ